### PR TITLE
added an executable script so that the user can set the hooks path in…

### DIFF
--- a/git_tool/hooks/post-commit
+++ b/git_tool/hooks/post-commit
@@ -4,7 +4,7 @@
 echo "Running feature-post-commit"
 
 COMMIT_ID=$(git rev-parse HEAD)
-git feature-commit $COMMIT_ID
+git feature commit $COMMIT_ID
 
 if [ $? -ne 0 ]; then
     echo "Error: git feature-commit failed."

--- a/git_tool/hooks/pre-commit
+++ b/git_tool/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Pre-Commit Hook: Assert that feature changes were staged and the script does not find reasons to not continue
 echo "Running feature-pre-commit"
-git feature-pre-commit
+git feature pre-commit
 
 if [ $? -ne 0 ]; then
   echo "Error: Pre-commit checks failed."

--- a/git_tool/hooks/prepare-commit-msg
+++ b/git_tool/hooks/prepare-commit-msg
@@ -5,7 +5,7 @@ COMMIT_MSG_FILE=$1
 COMMIT_SOURCE=$2
 SHA1=$3
 
-FEATURE_MSG=$(git feature-commit-msg)
+FEATURE_MSG=$(git feature commit-msg)
 
 if [ $? -ne 0 ]; then
     echo "Error: Failed to generate feature commit message."

--- a/git_tool/scripts_for_experiment/set_hooks_path.py
+++ b/git_tool/scripts_for_experiment/set_hooks_path.py
@@ -1,0 +1,42 @@
+import subprocess
+import os
+import sys
+import git_tool
+
+'''
+    This script sets the hooks path for git.
+    It has been added to the pyproject.toml file as "feature-init-hooks"
+    Originally, the user had to set the hooks path manually, but not anymore.
+'''
+
+def main():
+    try:
+        # Step 1: Get the path to the installed git_tool package
+        package_path = os.path.abspath(git_tool.__file__)
+        print(f"Located git_tool at: {package_path}")
+
+        # Step 2: Strip __init__.py and append 'hook'
+        base_path = os.path.dirname(package_path)
+        hook_path = os.path.join(base_path, "hooks")
+        print(f"Using hooks directory: {hook_path}")
+
+        # Step 3: Set git hooksPath
+        subprocess.run(["git", "config", "core.hooksPath", hook_path], check=True)
+        print("Git hooks path set successfully.")
+
+        # Step 4: Check the current hooks path
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        current_hook_path = result.stdout.strip()
+        print(f"Git is now using hooks from: {current_hook_path}")
+
+    except subprocess.CalledProcessError as e:
+        print("Git command failed:", e)
+        sys.exit(1)
+    except Exception as e:
+        print("Something went wrong:", e)
+        sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.scripts]
 git-feature = "git_tool.__main__.py:app"
+feature-init-hooks = "git_tool.scripts_for_experiment.set_hooks_path:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
… a single step using "feature-init-hooks".

Also found out that I forgot to update the .sh files themselves to use the correct git feature command names

Open: adding executable scripts to add manpage/webdoc